### PR TITLE
cleanup package organization, some bugfixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "Krusell_Smith-main"
+name = "Krusell_Smith"
 uuid = "a8bf2d27-e51b-41f1-b4dd-11bd26c66b4c"
 authors = ["ELatulippeUBC <elatulip@student.ubc.ca> and contributors"]
 version = "0.1.0"

--- a/src/KS_Main.jl
+++ b/src/KS_Main.jl
@@ -1,4 +1,6 @@
-include("KS_Structure.jl")
+#include("KS_Structure.jl")
+using Krusell_Smith
+
 using Plots     
 
 ksp = KSParameter(); # Create an instance of KSParameter defining parameters of the model

--- a/src/Krusell_Smith.jl
+++ b/src/Krusell_Smith.jl
@@ -1,0 +1,8 @@
+module Krusell_Smith
+
+include("KS_Structure.jl")
+
+export KSParameter, KSSolution, generate_shocks, compute_ALM_coef!, 
+    plot_Aggregate_Law_Motion_Capital, plot_Evolution_Aggregate_Capital,
+    Stochastic, LogUtility, CRRAUtility
+end

--- a/test/KS_test.jl
+++ b/test/KS_test.jl
@@ -1,9 +1,8 @@
 using Test
-include("../src/KS_Structure.jl")
+#include("../src/KS_Structure.jl")
+using Krusell_Smith
 
-println("-----------------------------------------------------")
-println("Test on the Parameter Grids")
-println("-----------------------------------------------------")
+# no need for printing headers, just use the testset name.
 ksp = KSParameter();
 kss = KSSolution(ksp); 
 @testset "Grid Tests" begin
@@ -11,12 +10,8 @@ kss = KSSolution(ksp);
     @test size(kss.k_opt,2) == length(ksp.K_grid)
 end;
 
-println("-----------------------------------------------------")
-println("Test on Functions --- Parameters ")
-println("-----------------------------------------------------")
-
 # Test QuantEcon Utility Functions with different paremeters θ
-@testset "Grid Tests" begin
+@testset "Functions -- Parameters" begin
     ksp_θ_1 = KSParameter(θ = 1)
     @test ksp_θ_1.u == LogUtility(1.0)
 
@@ -28,18 +23,19 @@ end;
 ksp = KSParameter();
 @test size(ksp.s_grid) == (4,2)
 
-println("-----------------------------------------------------")
-println("Test on Functions --- Maximum Iterations")
-println("-----------------------------------------------------")
+
 # Check that the maximum number of iterations was not reached 
 max_iter_B = 500; 
 max_iter_ump = 10000;
 
 @testset "Maximum Iterations Test" begin
-
+    import Random
     Random.seed!(0) 
+    ksp = KSParameter();
+    kss = KSSolution(ksp); 
     zi_shocks, epsi_shocks = generate_shocks(ksp;); 
     sm = Stochastic(epsi_shocks);
+    
     _, B_counter, counter = compute_ALM_coef!(sm, ksp, kss, zi_shocks, tol_ump = 1e-1, max_iter_ump = 10000, tol_B = 1e-1, max_iter_B = 500, update_B = 0.3, T_discard = 100);
 
     @test B_counter <= max_iter_B # Regression Method converged within tolerance level


### PR DESCRIPTION
I reorganized things into a package. This should make it compatible with running tests on github actions. The key changes were:

1. Create a Krusell_Smith.jl which just includes files defining functions and structs, and exports functions to be used elsewhere. 
2. Replace include("KS_Structure.jl") with using Krusell_Smith in tests and KS_Main.

This is a more standard way to organize a package. One advantage is that structs defined inside a module can be redefined without restarting julia. Another is that the scope of functions inside the package is better separated from the scope of the scripts using the functions. This lead to discovering two apparent scoping mistakes in `Expectation_FOC` and `epsi_zi_to_si`